### PR TITLE
Removing unnecessary gender on pronouns

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -95,14 +95,14 @@ Different types of certificates reflect different kinds of CA verification of in
 
 DV certificate validation commonly checks claims about properties related to control of a domain name -- properties that can be observed by the issuing authority in an interactive process that can be conducted purely online.  That means that under typical circumstances, all steps in the request, verification, and issuance process can be represented and performed by Internet protocols with no out-of-band human intervention.
 
-When an operator deploys a current HTTPS server, it generally prompts him to generate a self-signed certificate.  When an operator deploys an ACME-compatible web server, the experience would be something like this:
+When an operator deploys a current HTTPS server, it generally prompts them to generate a self-signed certificate.  When an operator deploys an ACME-compatible web server, the experience would be something like this:
 
 * The web server prompts the operator for the intended domain name(s)
   that the web server is to stand for.
 * The web server presents the operator with a list of CAs which it could
   get a certificate from using ACME.  The web server might prompt the operator for
   payment information at this point.
-* Once the operator has selected a CA, the web server tells the operator that he
+* Once the operator has selected a CA, the web server tells the operator that they
   will have a certificate shortly.
 * In the background, the web server contacts the CA and uses ACME to request that
   a certificate be issued for the intended domain name(s).
@@ -407,7 +407,7 @@ challenges (required, array):
 combinations (optional, array of arrays):
 : A collection of sets of challenges, each of which would be sufficient to prove possession of the identifier.  Clients SHOULD complete a set of challenges that that covers at least one set in this array.  Challenges are represented by their associated zero-based index in the challenges array.
 
-For example, if the server wants to have the client demonstrate both that the client controls the domain name in question, and that he is the same client that previously requested authorization for the domain name, it might issue the following request.  The client is expected to provide "simpleHttps" and "recoveryToken" responses ("[0,2]"), or else "dns" and "recoveryToken" responses ("[1,2]"), or all three.
+For example, if the server wants to have the client demonstrate both that the client controls the domain name in question, and that it is the same client that previously requested authorization for the domain name, it might issue the following request.  The client is expected to provide "simpleHttps" and "recoveryToken" responses ("[0,2]"), or else "dns" and "recoveryToken" responses ("[1,2]"), or all three.
 
 ~~~~~~~~~~
 {
@@ -534,7 +534,7 @@ Recovery tokens are employed in response to Recovery Challenges.  Such challenge
 
 ## Certificate Issuance
 
-The holder of an authorized key pair for an identifier may use ACME to request that a certificate be issued for that identifier.  He does so using a "certificateRequest" message, which contains a Certificate Signing Request (CSR) {{RFC2986}} and a signature by the authorized key pair.
+The holder of an authorized key pair for an identifier may use ACME to request that a certificate be issued for that identifier.  They do so using a "certificateRequest" message, which contains a Certificate Signing Request (CSR) {{RFC2986}} and a signature by the authorized key pair.
 
 type (required, string):
 : "certificateRequest"
@@ -682,7 +682,7 @@ The identifier validation challenges described in this section all relate to val
 
 ## Simple HTTPS
 
-With Simple HTTPS validation, the client in an ACME transaction proves his control over a domain name by proving that he can provision resources on an HTTPS server that responds for that domain name.  The ACME server challenges the client to provision a file with a specific string as its contents.
+With Simple HTTPS validation, the client in an ACME transaction proves its control over a domain name by proving that it can provision resources on an HTTPS server that responds for that domain name.  The ACME server challenges the client to provision a file with a specific string as its contents.
 
 type (required, string):
 : The string "simpleHttps"


### PR DESCRIPTION
While skimming the spec I noticed a few places where pronouns were used awkwardly; several were personal pronouns that were gender-specific, and several needed to be changed to the neuter pronoun "it" (such as when talking about a program.)

I went with the ever-more popular singular-they approach rather than rewriting sentences (since it's the least obtrusive approach.)
