### PR TITLE
Renewal URI response is optional (brackets added)

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -187,7 +187,7 @@ If the server agrees to issue the certificate, then it creates the certificate a
       Signature by auth'd key      -------->
 
                                                         Certificate
-                                   <--------            Renewal URI
+                                   <--------            [Renewal URI]
 
 ~~~~~~~~~~
 


### PR DESCRIPTION
From the paragraph explaining the certificate exchange:
```
If the server agrees to issue the certificate, then it creates the
certificate and provides it in its response. The server may also provide
a URI that can be used to renew the certificate, if it allows renewal
without re-validation.
```

The renewal URI is thus optional.