### PR TITLE
Add an "agreement" challenge

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -321,6 +321,9 @@ contact (optional, array of string):
 recoveryToken (optional, string):
 : An opaque token that the client can present to demonstrate that it participated in a prior authorization transaction.
 
+agreement (optional, string):
+: A URI referring to a subscriber agreement or terms of service provided by the server (see below).  Including this field indicates the client's agreement with these terms.
+
 A client creates a new account with the server by sending a POST request to the server's new-registration URI.  The body of the request is a registration object containing only the "contact" field.
 
 ~~~~~~~~~~
@@ -344,12 +347,16 @@ provided by the client.
 The server creates a registration object with the included contact information.  The "key" element of the registration is set to the public key used to verify the JWS (i.e., the "jwk" element of the JWS header).  The server also provides a random
 recovery token.  The server returns this registration object in a 201 (Created) response, with the registration URI in a Location header field.  The server may also indicate its new-authorization URI using the "next" link relation.
 
+If the server wishes to present the client with terms under which the ACME service is to be used, it may indicate the URI where such terms can be accessed in a Link header with link relation "terms-of-service".  As noted above, the client may indicate its
+agreement with these terms by updating its registration to include the "agreement" field, with the terms URI as its value.
+
 ~~~~~~~~~~
 
 HTTP/1.1 201 Created
 Content-Type: application/json
 Location: https://example.com/reg/asdf
 Link: <https://example.com/acme/new-authz>;rel="next"
+Link: <https://example.com/acme/terms>;rel="terms-of-service"
 
 {
   "key": { /* JWK from JWS header */ },
@@ -1082,42 +1089,6 @@ type (required, string):
 ~~~~~~~~~~
 
 To validate a DNS challenge, the server queries for TXT records under the validation domain name.  If it receives a record whose contents match the token in the challenge, then the validation succeeds.  Otherwise, the validation fails.
-
-## Subscriber Agreement / Terms of Use
-
-Some CAs require an applicant for a certificate to agree to a "subscriber agreement" or "terms of use".  In ACME, this requirement is can be expressed using the "agreement" challenge.  The challenge message includes a link to the agreement, in human-readable form.
-
-type (required, string):
-: The string "agreement"
-
-href (required, string):
-: An HTTP or HTTPS URI from which the agreement can be fetched, in human-readable form.
-
-~~~~~~~~~~
-
-{
-  "type": "agreement",
-  "href": "https://example.com/acme/terms/"
-}
-
-~~~~~~~~~~
-
-If the user agrees to the referenced agreement, the client indicates its agreement in its response to the challenge.
-
-type (required, string):
-: The string "agreement"
-
-agreed (required, boolean):
-: This value is set to "true" to indicate agreement, and "false" otherwise.
-
-~~~~~~~~~~
-
-{
-  "type": "agreement",
-  "agreed": true
-}
-
-~~~~~~~~~~
 
 
 ## Other possibilities

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1041,6 +1041,42 @@ type (required, string):
 
 To validate a DNS challenge, the server queries for TXT records under the validation domain name.  If it receives a record whose contents match the token in the challenge, then the validation succeeds.  Otherwise, the validation fails.
 
+## Subscriber Agreement / Terms of Use
+
+Some CAs require an applicant for a certificate to agree to a "subscriber agreement" or "terms of use".  In ACME, this requirement is can be expressed using the "agreement" challenge.  The challenge message includes a link to the agreement, in human-readable form.
+
+type (required, string):
+: The string "agreement"
+
+href (required, string):
+: An HTTP or HTTPS URI from which the agreement can be fetched, in human-readable form.
+
+~~~~~~~~~~
+
+{
+  "type": "dns",
+  "href": "https://example.com/acme/terms/"
+}
+
+~~~~~~~~~~
+
+If the user agrees to the referenced agreement, the client indicates its agreement in its response to the challenge.
+
+type (required, string):
+: The string "dns"
+
+agreed (required, boolean):
+: This value is set to "true" to indicate agreement, and "false" otherwise.
+
+~~~~~~~~~~
+
+{
+  "type": "agreement",
+  "agreed": true
+}
+
+~~~~~~~~~~
+
 
 ## Other possibilities
 

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1063,7 +1063,7 @@ href (required, string):
 If the user agrees to the referenced agreement, the client indicates its agreement in its response to the challenge.
 
 type (required, string):
-: The string "dns"
+: The string "agreement"
 
 agreed (required, boolean):
 : This value is set to "true" to indicate agreement, and "false" otherwise.

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1054,7 +1054,7 @@ href (required, string):
 ~~~~~~~~~~
 
 {
-  "type": "dns",
+  "type": "agreement",
   "href": "https://example.com/acme/terms/"
 }
 


### PR DESCRIPTION
The [CABF Baseline Requirements (Section 10.3.1)](https://cabforum.org/wp-content/uploads/BRv1.2.3.pdf) require CAs to obtain agreement with a "Subscriber Agreement" or "Terms of Use" before they will issue a certificate.  We can reflect this requirement in ACME with a new challenge type that allows an applicant for authorization to agree to terms for the issuance of certs under that authorization. 