### PR TITLE
Mention IPv6 and round-robin DNS situation

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -735,6 +735,8 @@ The identifier validation challenges described in this section all relate to val
 
 With Simple HTTPS validation, the client in an ACME transaction proves its control over a domain name by proving that it can provision resources on an HTTPS server that responds for that domain name.  The ACME server challenges the client to provision a file with a specific string as its contents.
 
+As a domain may resolve to multiple IPv4 and IPv6 addresses, the server will connect to at least one of the hosts found in A and AAAA records, at its discretion.  Simple HTTPS validation of IPv6-only domains may not be supported by all servers.
+
 type (required, string):
 : The string "simpleHttps"
 
@@ -783,7 +785,7 @@ If the GET request succeeds and the entity body is equal to the nonce, then the 
 
 The Domain Validation with Server Name Indication (DVSNI) validation method aims to ensure that the ACME client has administrative access to the web server at the domain name being validated, and possession of the private key being authorized.  The ACME server verifies that the operator can reconfigure the web server by having the client create a new self-signed challenge certificate and respond to TLS connections from the ACME server with it.
 
-The challenge proceeds as follows: The ACME server sends the client a random value R and a nonce used to identify the transaction.  The client responds with another random value S.  The server initiates a TLS connection on port 443 to a host with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension set to "\<nonce\>.acme.invalid".  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated and the domain name "\<Z\>.acme.invalid", where Z = SHA-256(R &#124;&#124; S).
+The challenge proceeds as follows: The ACME server sends the client a random value R and a nonce used to identify the transaction.  The client responds with another random value S.  The server initiates a TLS connection on port 443 to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension set to "\<nonce\>.acme.invalid".  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated and the domain name "\<Z\>.acme.invalid", where Z = SHA-256(R &#124;&#124; S).
 
 The ACME server's Challenge provides its random value R, and a random nonce used to identify the transaction:
 


### PR DESCRIPTION
I'm guessing that IPv6 records are ignored by the Simple HTTPS and DVSNI challenge methods? The current text seems to assume "the host for the domain" is uniquely defined, which puts an incorrect security model in the reader's head.

I think it's wise to explicitly exclude validation over IPv6 for now, because an attacker who controls the DNS zone could add an AAAA record to it without breaking the live site for most users, and if letsencrypt would send the challenge to that AAAA address, it would not be testing the "real" live site in practice.