### PR TITLE
Revocations can be authorized by account key.

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -686,9 +686,10 @@ Host: example.com
 Before revoking a certificate, the server MUST verify that the account key pair
 used to sign the request is authorized to revoke the certificate. Authorization
 may be proved by either: (a) signing the revocation request with the
-account key that was used to issue the certificate, or (b) providing a set of
-authorization resources that establish authorizations for all identifiers in the
-certificate.
+account key that was used to issue the certificate, or
+(b) providing a set of authorization resources that establish authorizations for
+all identifiers in the certificate and signing the revocation request with the
+account key that was used to issue the authorizations.
 
 If the revocation succeeds, the server responds with status code 200 (OK).  If the revocation fails, the server returns an error.
 

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -683,7 +683,12 @@ Host: example.com
 
 ~~~~~~~~~~
 
-Before revoking a certificate, the server MUST verify that the account key pair used to sign the request is authorized to act for all of the identifier(s) in the certificate.  The server MAY also accept a signature by the private key corresponding to the public key in the certificate.
+Before revoking a certificate, the server MUST verify that the account key pair
+used to sign the request is authorized to revoke the certificate. Authorization
+may be proved by either: (a) signing the revocation request with the
+account key that was used to issue the certificate, or (b) providing a set of
+authorization resources that establish authorizations for all identifiers in the
+certificate.
 
 If the revocation succeeds, the server responds with status code 200 (OK).  If the revocation fails, the server returns an error.
 


### PR DESCRIPTION
In other words, you don't have to provide a list of current authorizations if
you are using the same account key that issued the certificate.