### PR TITLE
Shift URIs around

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -324,10 +324,10 @@ agreement (optional, string):
 : A URI referring to a subscriber agreement or terms of service provided by the server (see below).  Including this field indicates the client's agreement with these terms.
 
 authorizations (optional, string):
-: A URI from which a list of authorizations granted to this account can be fetched via a GET request.  The result of the GET request MUST be a JSON array of strings, where each string is the URI of an authorization belonging to this registration.
+: A URI from which a list of authorizations granted to this account can be fetched via a GET request.  The result of the GET request MUST be a JSON object whose "authorizations" field is an array of strings, where each string is the URI of an authorization belonging to this registration.  The server SHOULD include pending authorizations, and SHOULD NOT include authorizations that are pending or expired.
 
 certificates (optional, string):
-: A URI from which a list of certificates issued for this account can be fetched via a GET request.  The result of the GET request MUST be a JSON array of strings, where each string is the URI of a certificate.
+: A URI from which a list of certificates issued for this account can be fetched via a GET request.  The result of the GET request MUST be a JSON object whose "certificates" field is an array of strings, where each string is the URI of a certificate.  The server SHOULD NOT include expired certificates.
 
 A client creates a new account with the server by sending a POST request to the server's new-registration URI.  The body of the request is a registration object containing only the "contact" field.
 
@@ -612,7 +612,7 @@ Recovery tokens are employed in response to Recovery Challenges.  Such challenge
 
 ## Certificate Issuance
 
-The holder of an authorized key pair for an identifier may use ACME to request that a certificate be issued for that identifier.  The client makes this request by sending a POST request to the server's new-certificate resource.  The body of the POST is a JWS object whose JSON payload contains a Certificate Signing Request (CSR) {{RFC2986}} and set of authorization URIs.  The CSR encodes the parameters of the requested certificate; authority to issue is demonstrated by the JWS signature, from which the server can look up related authorizations.
+The holder of an authorized key pair for an identifier may use ACME to request that a certificate be issued for that identifier.  The client makes this request by sending a POST request to the server's new-certificate resource.  The body of the POST is a JWS object whose JSON payload contains a Certificate Signing Request (CSR) {{RFC2986}}.  The CSR encodes the parameters of the requested certificate; authority to issue is demonstrated by the JWS signature, from which the server can look up related authorizations.
 
 csr (required, string):
 : A CSR encoding the parameters for the certificate being requested.  The CSR is sent in Base64-encoded version of the DER format.  (Note: This field uses the same modified Base64-encoding rules used elsewhere in this document, so it is different from PEM.)

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -324,7 +324,7 @@ agreement (optional, string):
 : A URI referring to a subscriber agreement or terms of service provided by the server (see below).  Including this field indicates the client's agreement with these terms.
 
 authorizations (optional, string):
-: A URI from which a list of authorizations granted to this account can be fetched via a GET request.  The result of the GET request MUST be a JSON object whose "authorizations" field is an array of strings, where each string is the URI of an authorization belonging to this registration.  The server SHOULD include pending authorizations, and SHOULD NOT include authorizations that are pending or expired.
+: A URI from which a list of authorizations granted to this account can be fetched via a GET request.  The result of the GET request MUST be a JSON object whose "authorizations" field is an array of strings, where each string is the URI of an authorization belonging to this registration.  The server SHOULD include pending authorizations, and SHOULD NOT include authorizations that are invalid or expired.
 
 certificates (optional, string):
 : A URI from which a list of certificates issued for this account can be fetched via a GET request.  The result of the GET request MUST be a JSON object whose "certificates" field is an array of strings, where each string is the URI of a certificate.  The server SHOULD NOT include expired certificates.

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -323,6 +323,12 @@ recoveryToken (optional, string):
 agreement (optional, string):
 : A URI referring to a subscriber agreement or terms of service provided by the server (see below).  Including this field indicates the client's agreement with these terms.
 
+authorizations (optional, string):
+: A URI from which a list of authorizations granted to this account can be fetched via a GET request.  The result of the GET request MUST be a JSON array of strings, where each string is the URI of an authorization belonging to this registration.
+
+certificates (optional, string):
+: A URI from which a list of certificates issued for this account can be fetched via a GET request.  The result of the GET request MUST be a JSON array of strings, where each string is the URI of a certificate.
+
 A client creates a new account with the server by sending a POST request to the server's new-registration URI.  The body of the request is a registration object containing only the "contact" field.
 
 ~~~~~~~~~~
@@ -373,7 +379,7 @@ Link: <https://example.com/acme/terms>;rel="terms-of-service"
 If the client wishes to update this information in the future, it sends a POST request with updated information to the registration URI.  The server MUST ignore any updates to the "key" or "recoveryToken" fields, and MUST verify that the request is signed
 with the private key corresponding to the "key" field of the request before updating the registration.
 
-Servers SHOULD NOT respond to GET requests for registration resources as these requests are not authenticated.
+Servers SHOULD NOT respond to GET requests for registration resources as these requests are not authenticated.  If a client wishes to query the server for information about its account (e.g., to examine the "contact" or "certificates" fields), then it SHOULD do so by sending a POST request with an empty update.  That is, it should send a JWS whose payload is the empty JSON dictionary ("{}").
 
 
 ## Authorization Resources

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -190,7 +190,7 @@ For example, if the client requests a domain name, the server might challenge th
 
 ~~~~~~~~~~
 
-Once the client has authorized an account key pair for an identifier, it can use the key pair to authorize the issuance of certificates for the identifier.  To do this, the client sends a PKCS#10 Certificate Signing Request (CSR) to the server (indicating the identifier(s) to be included in the issued certificate), a set of links to any required authorizations, and a signature over the CSR by the private key of the account key pair.
+Once the client has authorized an account key pair for an identifier, it can use the key pair to authorize the issuance of certificates for the identifier.  To do this, the client sends a PKCS#10 Certificate Signing Request (CSR) to the server (indicating the identifier(s) to be included in the issued certificate) and a signature over the CSR by the private key of the account key pair.
 
 If the server agrees to issue the certificate, then it creates the certificate and provides it in its response.  The certificate is assigned a URI, which the client can use to fetch updated versions of the certificate.
 
@@ -606,13 +606,10 @@ Recovery tokens are employed in response to Recovery Challenges.  Such challenge
 
 ## Certificate Issuance
 
-The holder of an authorized key pair for an identifier may use ACME to request that a certificate be issued for that identifier.  The client makes this request by sending a POST request to the server's new-certificate resource.  The body of the POST is a JWS object whose JSON payload contains a Certificate Signing Request (CSR) {{RFC2986}} and set of authorization URIs.  The CSR encodes the parameters of the requested certificate; authority to issue is demonstrated by the JWS signature and the linked authorizations.
+The holder of an authorized key pair for an identifier may use ACME to request that a certificate be issued for that identifier.  The client makes this request by sending a POST request to the server's new-certificate resource.  The body of the POST is a JWS object whose JSON payload contains a Certificate Signing Request (CSR) {{RFC2986}} and set of authorization URIs.  The CSR encodes the parameters of the requested certificate; authority to issue is demonstrated by the JWS signature, from which the server can look up related authorizations.
 
 csr (required, string):
 : A CSR encoding the parameters for the certificate being requested.  The CSR is sent in Base64-encoded version of the DER format.  (Note: This field uses the same modified Base64-encoding rules used elsewhere in this document, so it is different from PEM.)
-
-authorizations (required, array of string):
-: An array of URIs for authorization resources.
 
 ~~~~~~~~~~
 
@@ -622,9 +619,6 @@ Accept: application/pkix-cert
 
 {
   "csr": "5jNudRx6Ye4HzKEqT5...FS6aKdZeGsysoCo4H9P",
-  "authorizations": [
-    "https://example.com/acme/authz/asdf"
-  ]
 }
 /* Signed as JWS */
 
@@ -632,7 +626,7 @@ Accept: application/pkix-cert
 
 The CSR encodes the client's requests with regard to the content of the certificate to be issued.  The CSR MUST contain at least one extensionRequest attribute {{RFC2985}} requesting a subjectAltName extension, containing the requested identifiers.
 
-The values provided in the CSR are only a request, and are not guaranteed.  The server or CA may alter any fields in the certificate before issuance.  For example, the CA may remove identifiers that are not authorized for the key indicated in the "authorization" field.
+The values provided in the CSR are only a request, and are not guaranteed.  The server or CA may alter any fields in the certificate before issuance.  For example, the CA may remove identifiers that are not authorized for the account key that signed the request.
 
 If the CA decides to issue a certificate, then the server returns the certificate in a response with status code 201 (Created).  The server MUST indicate a URL for this certificate in a Location header field.
 


### PR DESCRIPTION
The existing messages have URIs present where they're not helpful, and missing where they would be helpful.  This PR makes two changes:

* Removes the "authorizations" URIs from the new-certificate request object
* Adds "certificates" and "authorizations" URIs to the registration object