### PR TITLE
Identifier Validation Challenges: clarify "Recertification by another CA"

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -709,7 +709,7 @@ The choice of which Challenges to offer to a client under which circumstances is
 | Existing valid certs, first use of ACME       | DV + Proof of Possession of previous CA-signed key    |
 | Ongoing ACME usage                            | PoP of previous Authorized key                        |
 | Ongoing ACME usage, lost Authorized key       | DV + PoP of ACME-certified Subject key                |
-| ACME usage, all keys and recovery tokens lost | Recertification by another CA + PoP of that key       |
+| ACME usage, all keys and recovery tokens lost | Proof of legal identity of the site owner             |
 
 The identifier validation challenges described in this section all relate to validation of domain names.  If ACME is extended in the future to support other types of identifier, there will need to be new Challenge types, and they will need to specify which types of identifier they apply to.
 


### PR DESCRIPTION
The ACME draft suggests that after a client has lost "all keys and recovery tokens", the CA should ask him to get a "recertification by another CA".

That would have no point: there would be no reason for a Certificate Authority to consider that a "Recertification by another CA" is more trustworthy than their "recertifying" the client themselves [1].

That statement seems to assume that "another CA" would perform a check of client's legal identity (as is currently done when issuing EV certificates). It may have been written with point of view of the "Let's encrypt" project which isn't going to be performing such checks (and would therefore rely on other CAs to perform them).

This patch clarifies the meaning.

---
[1] "After You were so silly to lose all Your keys and Your recovery token, we won't issue You another certificate. Please go to our competitor: he will require only Domain Validation." (This assumes that CAs won't share information and all CAs will use the policy described in the draft)