### PR TITLE
Add "authorizations" to /new-cert request

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -693,6 +693,7 @@ Accept: application/pkix-cert
 
 {
   "csr": "5jNudRx6Ye4HzKEqT5...FS6aKdZeGsysoCo4H9P",
+  "authorizations": ["https://example.com/authz/asdf"],
 }
 /* Signed as JWS */
 


### PR DESCRIPTION
Both the [server](https://github.com/letsencrypt/boulder/blob/master/ra/registration-authority.go#L269) and [client](https://github.com/letsencrypt/lets-encrypt-preview/blob/master/acme/messages2.py#L256) have an "authorizations" list when POSTing to /new-cert. However, the spec does not.

However, we should also add a definition to above the example. I'm unsure how to word that. The current server and client only look at the authorization id and not the challenge id. I'm guess that should be specified.