### PR TITLE
Clarify tokens in various challenges.

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1518,12 +1518,12 @@ type (required, string):
 token (required, string):
 : The value to be used in generation of validation JWS.  This value MUST have at
 least 128 bits of entropy, in order to prevent an attacker from guessing it.
-It MUST NOT contain any non-ASCII characters.
+It MUST NOT contain any characters outside the URL-safe Base64 alphabet.
 
 ~~~~~~~~~~
 {
   "type": "simpleHttp",
-  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+oA"
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
 }
 ~~~~~~~~~~
 
@@ -1617,12 +1617,14 @@ type (required, string):
 : The string "dvsni"
 
 token (required, string):
-: A random value with at least 128 bits of entropy, base64-encoded
+: The value to be used in generation of validation certificate.  This value MUST have at
+least 128 bits of entropy, in order to prevent an attacker from guessing it.
+It MUST NOT contain any characters outside the URL-safe Base64 alphabet.
 
 ~~~~~~~~~~
 {
   "type": "dvsni",
-  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJyPCt92wrDoA",
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
 }
 ~~~~~~~~~~
 
@@ -1634,12 +1636,12 @@ type (required, string):
 : The string "dvsni"
 
 token (required, string):
-: A random value with at least 128 bits of entropy, base64-encoded
+: The token value from the server-provided challenge object
 
 ~~~~~~~~~~
 {
   "type": "dvsni",
-  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJyPCt92wrDoA",
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
 }
 ~~~~~~~~~~
 
@@ -1826,13 +1828,15 @@ type (required, string):
 : The string "dns"
 
 token (required, string):
-: A random value with at least 128 bits of entropy.  It MUST NOT contain any
-characters outside the URL-safe Base64 alphabet.
+: The value to be used in generation of validation record to be provisioned
+in DNS.  This value MUST have at least 128 bits of entropy, in order to
+prevent an attacker from guessing it.  It MUST NOT contain any characters
+outside the URL-safe Base64 alphabet.
 
 ~~~~~~~~~~
 {
   "type": "dns",
-  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+oA",
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
 }
 ~~~~~~~~~~
 
@@ -1844,12 +1848,12 @@ type (required, string):
 : The string "dns"
 
 token (required, string):
-: The token value in the challenge
+: The token value from the server-provided challenge object
 
 ~~~~~~~~~~
 {
   "type": "dns",
-  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ+PCt92wr+oA",
+  "token": "evaGxfADs6pSRb2LAv9IZf17Dt3juxGJ-PCt92wr-oA"
 }
 ~~~~~~~~~~
 


### PR DESCRIPTION
Copies the language from the DNS challenge to the other challenges (characters must be in Base64 URL-safe set). This is particularly helpful for SimpleHTTP since it prohibits '/' and '.' in tokens, which wind up used in path names.

Fixes some tokens with characters outside the URL-safe base64 set, and fixes one
token that was randomly different from the other example tokens.

Fixes trailing commas in JSON.