### PR TITLE
DVSNI mitigations for default vhost vulnerability

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -884,7 +884,7 @@ If the GET request succeeds and the entity body is equal to the token, then the 
 
 The Domain Validation with Server Name Indication (DVSNI) validation method aims to ensure that the ACME client has administrative access to the web server at the domain name being validated, and possession of the private key being authorized.  The ACME server verifies that the operator can reconfigure the web server by having the client create a new self-signed challenge certificate and respond to TLS connections from the ACME server with it.
 
-The challenge proceeds as follows: The ACME server sends the client a random value R, a number of challenge iterations, N, and a list of acceptable ports for which to perform the challenge. The client responds with a chosen port.  The server initiates multiple TLS connection on the client's specified port to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension to "\<Ri[:32]\>.\<Ri[32:]\>.acme.invalid" where Ri is calculated by SHA256(Ri-1).  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated with the suffix ".acme.invalid" and the domain name "\<Ri[:32]\>.\<Ri[32:]\>.acme.invalid".
+The challenge proceeds as follows: The ACME server sends the client a random value R, a number of challenge iterations, N, and a list of acceptable ports for which to perform the challenge. The client responds with a chosen port.  The server initiates multiple TLS connection on the client's specified port to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension to "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid" where Ri is calculated by SHA256(Ri-1).  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated with the suffix ".acme.invalid" and the domain name "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid".
 
 The ACME server's Challenge provides the following values.
 
@@ -916,7 +916,7 @@ The client responds to this Challenge by configuring a TLS server on one of the 
 1. Decode the server's random value R
 2. Generate R1...R(n-1) where Ri is computed as the SHA256 of R(i-1)
 3. For each iteration of R, generate a self-signed certificate with a subjectAltName extension containing two dNSName values:
-  1. A name formed by hex encoding "\<Ri\>[:32].\<Ri\>[32:].acme.invalid", referred to as the "DNS R name".
+  1. A name formed by hex encoding "\<Ri\>[0:32].\<Ri\>[32:64].acme.invalid", referred to as the "DNS R name".
   2. The requested domain appended with the suffix, ".acme.invalid"
 4. Configure the TLS server such that when a client presents the DNS R name in the SNI field, the server presents the generated certificate.
 

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1613,18 +1613,12 @@ failed.
 ## Domain Validation with Server Name Indication (DVSNI)
 
 The Domain Validation with Server Name Indication (DVSNI) validation method
-proves control over one or more domain names in parallel by showing that the
-client fully controls an HTTPS webserver or other TLS server, which is
-typically equivalent to root or administrator access.  It allows an arbitrary
-number M of domain names to be validated with a constant number of TCP
-connections to the TLS server, though the number of DNS queries remains
-proportional to M.
-
-DVSNI operates by requiring the client to configure a TLS server referenced by
-an A/AAAA record under the domain name to respond to specific connection
-attempts utilizing the Server Name Indication extension {{RFC6066}}. The
-server verifies the client's challenge by accessing the reconfigured server
-and verifying a particular challenge certificate is presented.
+proves control over a domain name by requiring the client to configure a TLS
+server referenced by an A/AAAA record under the domain name to respond to
+specific connection attempts utilizing the Server Name Indication extension
+{{RFC6066}}. The server verifies the client's challenge by accessing the
+reconfigured server and verifying a particular challenge certificate is
+presented.
 
 type (required, string):
 : The string "dvsni"

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1620,8 +1620,6 @@ specific connection attempts utilizing the Server Name Indication extension
 reconfigured server and verifying a particular challenge certificate is
 presented.
 
-The challenge proceeds as follows: The ACME server sends the client a random value R, a number of challenge iterations, N, and a list of acceptable ports for which to perform the challenge. The client responds with a chosen port.  The server initiates multiple TLS connection on the client's specified port to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension to "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid" where Ri is calculated by SHA256(Ri-1).  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing the domain name "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid".
-
 type (required, string):
 : The string "dvsni"
 

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1658,7 +1658,7 @@ hexadecimal form. The client then generates Z1...Z(n-1) where Zi is computed
 as the hexadecimal(SHA256(Z(i-1))).
 
 The client will generate a self-signed certificate for each iteration of Zi
-with the subjectAlternativeName extension containing the dNSName
+with a single subjectAlternativeName extension dNSName that is
 "\<Zi[0:32]\>.\<Zi[32:64]\>.acme.invalid".  The client will then configure the TLS
 server at the domain such that when a handshake is initiated with the Server
 Name Indication extension set to "\<Zi[0:32]\>.\<Zi[32:64]\>.acme.invalid", the
@@ -1698,11 +1698,14 @@ challenge.  For instance testing a subset of 5 of N=25 domains ensures that
 such an attacker has only a one in 25^5 chance of success if they post certs
 Zn in random succession.
 
-It is RECOMMENDED clients respond with DVSNI certificates for only the Z values
-specified by the CA.
+It is RECOMMENDED clients respond with DVSNI certificates for only the Z
+values specified by the CA.  The ACME server MUST ensure that each DVSNI
+certificate contains only the Z value it is searching for, and not multiple Z
+values in a single certificate.
 
 It is RECOMMENDED that the ACME server validation TLS connections from multiple
 vantage points to reduce the risk of DNS hijacking attacks.
+
 
 If all of the above verifications succeed, then the validation is successful.
 Otherwise, the validation fails.

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -884,7 +884,7 @@ If the GET request succeeds and the entity body is equal to the token, then the 
 
 The Domain Validation with Server Name Indication (DVSNI) validation method aims to ensure that the ACME client has administrative access to the web server at the domain name being validated, and possession of the private key being authorized.  The ACME server verifies that the operator can reconfigure the web server by having the client create a new self-signed challenge certificate and respond to TLS connections from the ACME server with it.
 
-The challenge proceeds as follows: The ACME server sends the client a random value R, a number of challenge iterations, N, and a list of acceptable ports for which to perform the challenge. The client responds with a chosen port.  The server initiates multiple TLS connection on the client's specified port to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension to "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid" where Ri is calculated by SHA256(Ri-1).  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated with the suffix ".acme.invalid" and the domain name "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid".
+The challenge proceeds as follows: The ACME server sends the client a random value R, a number of challenge iterations, N, and a list of acceptable ports for which to perform the challenge. The client responds with a chosen port.  The server initiates multiple TLS connection on the client's specified port to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension to "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid" where Ri is calculated by SHA256(Ri-1).  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing the domain name "\<Ri[0:32]\>.\<Ri[32:64]\>.acme.invalid".
 
 The ACME server's Challenge provides the following values.
 
@@ -915,9 +915,8 @@ The client responds to this Challenge by configuring a TLS server on one of the 
 
 1. Decode the server's random value R
 2. Generate R1...R(n-1) where Ri is computed as the SHA256 of R(i-1)
-3. For each iteration of R, generate a self-signed certificate with a subjectAltName extension containing two dNSName values:
+3. For each iteration of R, generate a self-signed certificate with a subjectAltName extension containing the dNSName value:
   1. A name formed by hex encoding "\<Ri\>[0:32].\<Ri\>[32:64].acme.invalid", referred to as the "DNS R name".
-  2. The requested domain appended with the suffix, ".acme.invalid"
 4. Configure the TLS server such that when a client presents the DNS R name in the SNI field, the server presents the generated certificate.
 
 The client SHOULD introduce its own entropy into each certificates, for example, by using a random serial number.
@@ -946,8 +945,7 @@ Given a Challenge/Response pair, the ACME server verifies the client's control o
 3. Verify the following properties of the certificates provided by the TLS server:
   * It is a valid self-signed certificate
   * The public key is the public key for the key pair being authorized
-  * It contains the domain name being validated with the suffix, ".acme.invalid" as a subjectAltName
-  * It contains a subjectAltName matching the DNS R name"
+  * It contains a subjectAltName matching the DNS R name
 
 It is RECOMMENDED that the ACME server verify the challenge certificate using multi-path probing techniques to reduce the risk of DNS hijacking attacks.
 

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1670,7 +1670,7 @@ type (required, string):
 : The string "dvsni"
 
 port (required, int):
-: One of the valid ports specified by the server, Base64-encoded
+: One of the valid ports specified by the server
 
 ~~~~~~~~~~
 {

--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -884,9 +884,9 @@ If the GET request succeeds and the entity body is equal to the token, then the 
 
 The Domain Validation with Server Name Indication (DVSNI) validation method aims to ensure that the ACME client has administrative access to the web server at the domain name being validated, and possession of the private key being authorized.  The ACME server verifies that the operator can reconfigure the web server by having the client create a new self-signed challenge certificate and respond to TLS connections from the ACME server with it.
 
-The challenge proceeds as follows: The ACME server sends the client a random value R and a nonce used to identify the transaction.  The client responds with another random value S.  The server initiates a TLS connection on port 443 to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension set to "\<nonce\>.acme.invalid".  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated and the domain name "\<Z\>.acme.invalid", where Z = SHA-256(R &#124;&#124; S).
+The challenge proceeds as follows: The ACME server sends the client a random value R, a number of challenge iterations, N, and a list of acceptable ports for which to perform the challenge. The client responds with a chosen port.  The server initiates multiple TLS connection on the client's specified port to one or more of the IPv4 or IPv6 hosts with the domain name being validated.  In the handshake, the ACME server sets the Server Name Indication extension to "\<Ri[:32]\>.\<Ri[32:]\>.acme.invalid" where Ri is calculated by SHA256(Ri-1).  The TLS server (i.e., the ACME client) should respond with a valid self-signed certificate containing both the domain name being validated with the suffix ".acme.invalid" and the domain name "\<Ri[:32]\>.\<Ri[32:]\>.acme.invalid".
 
-The ACME server's Challenge provides its random value R, and a random nonce used to identify the transaction:
+The ACME server's Challenge provides the following values.
 
 type (required, string):
 : The string "dvsni"
@@ -894,60 +894,66 @@ type (required, string):
 r (required, string):
 : A random 32-byte octet, Base64-encoded
 
-nonce (required, string):
-: A random 16-byte octet string, hex-encoded (so that it can be used as a DNS label)
+n (required, int):
+: Number of DVSNI iterations
+
+ports (required, array of int):
+: Acceptable ports to perform the challenge
 
 ~~~~~~~~~~
 
 {
   "type": "dvsni",
   "r": "Tyq0La3slT7tqQ0wlOiXnCY2vyez7Zo5blgPJ1xt5xI",
-  "nonce": "a82d5ff8ef740d12881f6d3c2277ab2e"
+  "n": 25,
+  "ports": [443],
 }
 
 ~~~~~~~~~~
 
-The client responds to this Challenge by configuring a TLS server on port 443 of a server with the domain name being validated:
+The client responds to this Challenge by configuring a TLS server on one of the specified ports.  The client performs the following steps:
 
 1. Decode the server's random value R
-2. Generate a random 32-byte octet string S
-3. Compute Z = SHA-256(R &#124;&#124; S) (where &#124;&#124; denotes concatenation of octet strings)
-4. Generate a self-signed certificate with a subjectAltName extension containing two dNSName values:
-  1. The domain name being validated
-  2. A name formed by hex-encoding Z and appending the suffix ".acme.invalid"
-5. Compute a nonce domain name by appending the suffix ".acme.invalid" to the nonce provided by the server.
-6. Configure the TLS server such that when a client presents the nonce domain name in the SNI field, the server presents the generated certificate.
+2. Generate R1...R(n-1) where Ri is computed as the SHA256 of R(i-1)
+3. For each iteration of R, generate a self-signed certificate with a subjectAltName extension containing two dNSName values:
+  1. A name formed by hex encoding "\<Ri\>[:32].\<Ri\>[32:].acme.invalid", referred to as the "DNS R name".
+  2. The requested domain appended with the suffix, ".acme.invalid"
+4. Configure the TLS server such that when a client presents the DNS R name in the SNI field, the server presents the generated certificate.
 
-The client's response provides its random value S:
+The client SHOULD introduce its own entropy into each certificates, for example, by using a random serial number.
+
+The client's responds with the following values.
 
 type (required, string):
 : The string "dvsni"
 
-s (required, string):
-: A random 32-byte secret octet string, Base64-encoded
+port (required, int):
+: One of the valid ports specified by the server, Base64-encoded
 
 ~~~~~~~~~~
 
 {
   "type": "dvsni",
-  "s": "9dbjsl3gTAtOnEtKFEmhS6Mj-ajNjDcOmRkp3Lfzm3c"
+  "port": 443,
 }
 
 ~~~~~~~~~~
 
 Given a Challenge/Response pair, the ACME server verifies the client's control of the domain by verifying that the TLS server was configured as expected:
 
-1. Compute the value Z = SHA-256(R &#124;&#124; S)
-2. Open a TLS connection to the domain name being validated on port 443, presenting the value "\<nonce\>.acme.invalid" in the SNI field.
-3. Verify the following properties of the certificate provided by the TLS server:
+1. Choose a set of DVSNI iterations to check.
+2. For each iteration, open a TLS connection to the domain name being validated on the specified port, presenting the appropriate DNS R name in the SNI field.
+3. Verify the following properties of the certificates provided by the TLS server:
   * It is a valid self-signed certificate
   * The public key is the public key for the key pair being authorized
-  * It contains the domain name being validated as a subjectAltName
-  * It contains a subjectAltName matching the hex-encoding of Z, with the suffix ".acme.invalid"
+  * It contains the domain name being validated with the suffix, ".acme.invalid" as a subjectAltName
+  * It contains a subjectAltName matching the DNS R name"
 
 It is RECOMMENDED that the ACME server verify the challenge certificate using multi-path probing techniques to reduce the risk of DNS hijacking attacks.
 
-If the server presents a certificate matching all of the above criteria, then the validation is successful.  Otherwise, the validation fails.
+It is RECOMMENDED that the ACME server verify an appropriate number of R value iterations to avoid default virtual host vulnerabilities in shared hosting environments.
+
+If the server presents certificates matching all of the above criteria, then the validation is successful.  Otherwise, the validation fails.
 
 
 ## Proof of Possession of a Prior Key


### PR DESCRIPTION
In addition to signature reuse, DVSNI2 should also be protected against the case where a tenant on a virtual hosting platform is accidentally the default vhost if a nonexistent domain is requested over HTTPS.

[Further details on this vulnerability](https://mailarchive.ietf.org/arch/msg/acme/B9vhPSMm9tcNoPrTE_LNhnt0d8U).