### PR TITLE
A minimal fix for the SimpleHTTPS default vhost vulnerability

### DIFF
--- a/draft-barnes-acme.md
+++ b/draft-barnes-acme.md
@@ -1179,7 +1179,6 @@ Host: example.com
 {
   "resource": "challenge",
   "type": "simpleHttp",
-  "tls": false
 }
 /* Signed as JWS */
 ~~~~~~~~~~
@@ -1563,23 +1562,16 @@ the HTTP server for the domain in question.
 ~~~~~~~~~~
 
 The resource MUST be provisioned under the fixed path
-".well-known/acme-challenge/".
-
-The client's response to this challenge indicates whether it would prefer for
-the validation request to be sent over TLS:
+".well-known/acme-challenge/".  Because many webservers allocate a default
+HTTPS virtual host to a particular low-privilege tenant user in a subtle and
+non-intuitive manner, the challenge must be completed over HTTP, not HTTPS.
 
 type (required, string):
 : The string "simpleHttp"
 
-tls (optional, boolean, default true):
-: If this attribute is present and set to "false", the server will perform its
-validation check over unencrypted HTTP (on port 80) rather than over HTTPS.
-Otherwise the check will be done over HTTPS, on port 443.
-
 ~~~~~~~~~~
 {
   "type": "simpleHttp",
-  "tls": false
 }
 /* Signed as JWS */
 ~~~~~~~~~~


### PR DESCRIPTION
- We remove the tls flag that allows clients to request port 443 Simple HTTPS
- The server can still safely-follow a redirect to HTTPS if it receives one in response to its HTTP request.

Details on the vulnerability [here](https://mailarchive.ietf.org/arch/msg/acme/B9vhPSMm9tcNoPrTE_LNhnt0d8U).